### PR TITLE
Add GPT Telegram bot example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
 單純就是無聊練習，至少有個開始
+
+## GPT Telegram Bot
+
+本倉庫內提供一個簡易範例 `gpt_telegram_bot.py`，可透過 GPT-3.5/4 回覆 Telegram 訊息。
+
+### 安裝依賴
+```bash
+pip install -r requirements.txt
+```
+
+### 環境變數
+- `TELEGRAM_TOKEN`：Telegram Bot 的 token
+- `OPENAI_API_KEY`：OpenAI API 金鑰
+
+### 執行方式
+```bash
+python gpt_telegram_bot.py
+```

--- a/gpt_telegram_bot.py
+++ b/gpt_telegram_bot.py
@@ -1,0 +1,31 @@
+import os
+import openai
+from telegram import Update
+from telegram.ext import ApplicationBuilder, MessageHandler, ContextTypes, filters
+
+TELEGRAM_TOKEN = os.getenv("TELEGRAM_TOKEN")
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+
+openai.api_key = OPENAI_API_KEY
+
+async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    user_text = update.message.text
+    try:
+        resp = openai.ChatCompletion.create(
+            model="gpt-3.5-turbo",
+            messages=[{"role": "user", "content": user_text}],
+        )
+        reply = resp.choices[0].message.content.strip()
+    except Exception as e:
+        reply = f"Error: {e}"
+    await update.message.reply_text(reply)
+
+def main() -> None:
+    if not TELEGRAM_TOKEN or not OPENAI_API_KEY:
+        raise EnvironmentError("TELEGRAM_TOKEN and OPENAI_API_KEY must be set")
+    app = ApplicationBuilder().token(TELEGRAM_TOKEN).build()
+    app.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, handle_message))
+    app.run_polling()
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
 requests
 beautifulsoup4
 pandas
+
+openai
+python-telegram-bot


### PR DESCRIPTION
## Summary
- add `openai` and `python-telegram-bot` to requirements
- create `gpt_telegram_bot.py` for replying to Telegram messages with OpenAI
- document usage and environment variables in README

## Testing
- `python -m py_compile gpt_telegram_bot.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68404dc9d5908330b2e86a947afc7276